### PR TITLE
Increase CommandTimeout

### DIFF
--- a/SSAS.PS1
+++ b/SSAS.PS1
@@ -36,6 +36,8 @@ $command = $connection.CreateCommand()
 $command.CommandText = $query
 $adapter = New-Object -TypeName System.Data.OleDb.OleDbDataAdapter $command
 $dataset = New-Object -TypeName System.Data.DataSet
+# CommandTimeout increased to 4 minutes
+$adapter.SelectCommand.CommandTimeout = 240
 $adapter.Fill($dataset)
 
 $dataset.Tables[0] | export-csv $filename -notypeinformation


### PR DESCRIPTION
The 30 seconds command timeout is request-driven, not a limitation of PowerBI's SSAS, so we can increase to avoid timeouts.
Note that ps1 can use a lot of ram when exporting big csv files and take a while... but it ends up working.